### PR TITLE
Feature: Display reblog/fav counts and avatars on timeline and status detail

### DIFF
--- a/app/javascript/mastodon/components/account_mini.js
+++ b/app/javascript/mastodon/components/account_mini.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import PropTypes from 'prop-types';
+import Avatar from './avatar';
+import Permalink from './permalink';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import Icon from 'mastodon/components/icon';
+import classNames from 'classnames';
+
+export default class AccountMini extends ImmutablePureComponent {
+
+  static propTypes = {
+    reblog: PropTypes.bool,
+    accounts: ImmutablePropTypes.list.isRequired,
+    intl: PropTypes.object.isRequired,
+  };
+
+  render () {
+    const { reblog, accounts } = this.props;
+
+    if (!accounts || accounts.size < 1) {
+      return <div />;
+    }
+
+    const avatars = accounts.map(account => (
+      <Permalink
+        key={account.get('id')}
+        className='account__avatar'
+        title={account.get('acct')}
+        href={account.get('url')}
+        to={`/accounts/${account.get('id')}`}
+      >
+        <div className='account__avatar-wrapper'>
+          <Avatar account={account} size={18} inline />
+        </div>
+      </Permalink>
+    ));
+
+    return (
+      <div className='mini-avatars'>
+        <div className={classNames('title', reblog ? 'reblog' : 'favourite')}>
+          <Icon id={reblog ? 'retweet' : 'star'} />
+        </div>
+        <div className='avatars'>
+          {avatars}
+        </div>
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/components/account_mini.js
+++ b/app/javascript/mastodon/components/account_mini.js
@@ -12,7 +12,6 @@ export default class AccountMini extends ImmutablePureComponent {
   static propTypes = {
     reblog: PropTypes.bool,
     accounts: ImmutablePropTypes.list.isRequired,
-    intl: PropTypes.object.isRequired,
   };
 
   render () {

--- a/app/javascript/mastodon/components/status_action_bar.js
+++ b/app/javascript/mastodon/components/status_action_bar.js
@@ -3,7 +3,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
 import IconButton from './icon_button';
 import DropdownMenuContainer from '../containers/dropdown_menu_container';
-import { defineMessages, injectIntl } from 'react-intl';
+import { defineMessages, injectIntl, FormattedNumber } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { me, isStaff } from '../initial_state';
 
@@ -249,9 +249,16 @@ class StatusActionBar extends ImmutablePureComponent {
 
     return (
       <div className='status__action-bar'>
-        <div className='status__action-bar__counter'><IconButton className='status__action-bar-button' title={replyTitle} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} /><span className='status__action-bar__counter__label' >{obfuscatedCount(status.get('replies_count'))}</span></div>
-        <IconButton className='status__action-bar-button' disabled={!publicStatus} active={status.get('reblogged')} pressed={status.get('reblogged')} title={!publicStatus ? intl.formatMessage(messages.cannot_reblog) : intl.formatMessage(messages.reblog)} icon={reblogIcon} onClick={this.handleReblogClick} />
-        <IconButton className='status__action-bar-button star-icon' animate active={status.get('favourited')} pressed={status.get('favourited')} title={intl.formatMessage(messages.favourite)} icon='star' onClick={this.handleFavouriteClick} />
+        <div className='status__action-bar__counter'>
+          <IconButton className='status__action-bar-button' title={replyTitle} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} />
+          <span className='status__action-bar__counter__label'>{obfuscatedCount(status.get('replies_count'))}</span>
+
+          <IconButton className='status__action-bar-button' disabled={!publicStatus} active={status.get('reblogged')} pressed={status.get('reblogged')} title={!publicStatus ? intl.formatMessage(messages.cannot_reblog) : intl.formatMessage(messages.reblog)} icon={reblogIcon} onClick={this.handleReblogClick} />
+          <span className='status__action-bar__counter__label'><FormattedNumber value={status.get('reblogs_count')} /></span>
+
+          <IconButton className='status__action-bar-button star-icon' animate active={status.get('favourited')} pressed={status.get('favourited')} title={intl.formatMessage(messages.favourite)} icon='star' onClick={this.handleFavouriteClick} />
+          <span className='status__action-bar__counter__label'><FormattedNumber value={status.get('favourites_count')} /></span>
+        </div>
         {shareButton}
 
         <div className='status__action-bar-dropdown'>

--- a/app/javascript/mastodon/containers/account_mini_container.js
+++ b/app/javascript/mastodon/containers/account_mini_container.js
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux';
+import { injectIntl } from 'react-intl';
+import { makeGetAccount } from '../selectors';
+import AccountMini from '../components/account_mini';
+
+const makeMapStateToProps = () => {
+  const getAccount = makeGetAccount();
+
+  const mapStateToProps = (state, props) => ({
+    accounts: props.accountIds.map(id => getAccount(state, id)),
+  });
+
+  return mapStateToProps;
+};
+
+export default injectIntl(connect(makeMapStateToProps)(AccountMini));

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6498,3 +6498,32 @@ noscript {
     }
   }
 }
+
+.mini-avatars {
+  background: lighten($ui-base-color, 4%);
+  padding: 0 10px 14px 10px;
+  display: flex;
+
+  .title {
+    float: left;
+    margin-right: 6px;
+    min-width: 16px;
+    font-size: 14px;
+    vertical-align: middle;
+  }
+
+  .reblog {
+    color: $highlight-text-color;
+  }
+
+  .favourite {
+    color: $gold-star;
+  }
+
+  .avatars {
+    .account__avatar-wrapper {
+      float: left;
+      margin: 2px 0;
+    }
+  }
+}


### PR DESCRIPTION
## Display reblog/fav counts on timeline

<img width="1465" alt="1_tl" src="https://user-images.githubusercontent.com/30565780/66939493-1e83a400-f07e-11e9-9b38-74af9ba898ba.png">

## Display reblog/fav avatars on status detail

<img width="1465" alt="2_status" src="https://user-images.githubusercontent.com/30565780/66939501-22afc180-f07e-11e9-85d1-22321bedfba7.png">

### when wrapped:

![3_wrapped](https://user-images.githubusercontent.com/30565780/66939523-28a5a280-f07e-11e9-8d02-3a55af53faea.png)

### in advanced-ui:

![4_advanced](https://user-images.githubusercontent.com/30565780/66939534-2e9b8380-f07e-11e9-9afd-34064aec3449.png)
