### PR TITLE
Feature: display rebfavs on static pages

### DIFF
--- a/app/controllers/concerns/rebfav_concern.rb
+++ b/app/controllers/concerns/rebfav_concern.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RebfavConcern
+  extend ActiveSupport::Concern
+
+  REBFAV_ACCOUNTS_LIMIT  = 400
+
+  def set_reblogged_accounts
+    @reblogged_accounts = Account
+      .includes(:statuses, :account_stat)
+      .references(:statuses)
+      .merge(Status
+          .where(reblog_of_id: @status.id)
+          .where(visibility: [:public, :unlisted])
+          .order(created_at: :desc)
+          .limit(REBFAV_ACCOUNTS_LIMIT))
+      .reverse
+  end
+
+  def set_favourited_accounts
+    @favourited_accounts = Account
+      .includes(:favourites, :account_stat)
+      .references(:favourites)
+      .where(favourites: { status_id: @status.id })
+      .merge(Favourite
+        .order(created_at: :desc)
+        .limit(REBFAV_ACCOUNTS_LIMIT))
+      .reverse
+  end
+end

--- a/app/controllers/concerns/rebfav_concern.rb
+++ b/app/controllers/concerns/rebfav_concern.rb
@@ -3,7 +3,7 @@
 module RebfavConcern
   extend ActiveSupport::Concern
 
-  REBFAV_ACCOUNTS_LIMIT  = 400
+  REBFAV_ACCOUNTS_LIMIT = 400
 
   def set_reblogged_accounts
     @reblogged_accounts = Account

--- a/app/controllers/concerns/status_controller_concern.rb
+++ b/app/controllers/concerns/status_controller_concern.rb
@@ -6,7 +6,6 @@ module StatusControllerConcern
   ANCESTORS_LIMIT         = 40
   DESCENDANTS_LIMIT       = 60
   DESCENDANTS_DEPTH_LIMIT = 20
-  REBFAV_ACCOUNTS_LIMIT  = 400
 
   def create_descendant_thread(starting_depth, statuses)
     depth = starting_depth + statuses.size
@@ -84,28 +83,5 @@ module StatusControllerConcern
     end
 
     @max_descendant_thread_id = @descendant_threads.pop[:statuses].first.id if descendants.size >= DESCENDANTS_LIMIT
-  end
-
-  def set_reblogged_accounts
-    @reblogged_accounts = Account
-      .includes(:statuses, :account_stat)
-      .references(:statuses)
-      .merge(Status
-          .where(reblog_of_id: @status.id)
-          .where(visibility: [:public, :unlisted])
-          .order(created_at: :desc)
-          .limit(REBFAV_ACCOUNTS_LIMIT))
-      .reverse
-  end
-
-  def set_favourited_accounts
-    @favourited_accounts = Account
-      .includes(:favourites, :account_stat)
-      .references(:favourites)
-      .where(favourites: { status_id: @status.id })
-      .merge(Favourite
-        .order(created_at: :desc)
-        .limit(REBFAV_ACCOUNTS_LIMIT))
-      .reverse
   end
 end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -5,6 +5,7 @@ class StatusesController < ApplicationController
   include SignatureAuthentication
   include Authorization
   include AccountOwnedConcern
+  include RebfavConcern
 
   layout 'public'
 

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -31,6 +31,8 @@ class StatusesController < ApplicationController
         expires_in 10.seconds, public: true if current_account.nil?
         set_ancestors
         set_descendants
+        set_reblogged_accounts
+        set_favourited_accounts
       end
 
       format.json do

--- a/app/helpers/mini_account_helper.rb
+++ b/app/helpers/mini_account_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module MiniAccountHelper
+  def mini_account(account, size: 24)
+    content_tag(:div, class: 'mini-avatar') do
+      content_tag(:div, class: 'account__avatar-wrapper') do
+        content_tag(:div, '', class: 'account__avatar account__avatar-inline', style: "width: #{size}px; height: #{size}px; background-size: #{size}px #{size}px; background-image: url(#{full_asset_url(current_account&.user&.setting_auto_play_gif ? account.avatar_original_url : account.avatar_static_url)})")
+      end
+    end
+  end
+end

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -26,3 +26,5 @@
 @import 'mastodon/dashboard';
 @import 'mastodon/rtl';
 @import 'mastodon/accessibility';
+
+@import 'mastodon/mini_avatars';

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6498,38 +6498,3 @@ noscript {
     }
   }
 }
-
-.rebfavs {
-  background: lighten($ui-base-color, 4%);
-
-  a {
-    display: flex;
-    align-items: center;
-    white-space: nowrap;
-
-    i {
-      display: inline-flex;
-      min-width: 16px;
-    }
-
-    .detailed-status {
-      &__reblogs,&__favorites {
-        display: inline-flex;
-        margin: 0 4px;
-        min-width: 16px;
-        font-size: 14px;
-      }
-    }
-
-    .mini-avatars {
-      display: inline-flex;
-      flex-wrap: wrap;
-      
-      .mini-avatar {
-        .account__avatar-wrapper {
-          margin: 2px 0;
-        }
-      }
-    }
-  }
-}

--- a/app/javascript/styles/mastodon/mini_avatars.scss
+++ b/app/javascript/styles/mastodon/mini_avatars.scss
@@ -23,7 +23,7 @@
     .mini-avatars {
       display: inline-flex;
       flex-wrap: wrap;
-      
+
       .mini-avatar {
         .account__avatar-wrapper {
           margin: 2px 0;

--- a/app/javascript/styles/mastodon/mini_avatars.scss
+++ b/app/javascript/styles/mastodon/mini_avatars.scss
@@ -1,0 +1,40 @@
+.rebfavs {
+  background: lighten($ui-base-color, 4%);
+
+  a {
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+
+    i {
+      display: inline-flex;
+      min-width: 16px;
+    }
+
+    .detailed-status {
+      &__reblogs,&__favorites {
+        display: inline-flex;
+        margin: 0 4px;
+        min-width: 16px;
+        font-size: 14px;
+      }
+    }
+
+    .mini-avatars {
+      display: inline-flex;
+      flex-wrap: wrap;
+      
+      .mini-avatar {
+        .account__avatar-wrapper {
+          margin: 2px 0;
+        }
+      }
+    }
+  }
+}
+
+.public-layout {
+  .detailed-status__meta.rebfavs {
+    margin-top: 15px;
+  }
+}

--- a/app/views/statuses/_detailed_status.html.haml
+++ b/app/views/statuses/_detailed_status.html.haml
@@ -59,8 +59,8 @@
       - else
         = fa_icon('reply-all')
       %span.detailed-status__reblogs>= number_to_human status.replies_count, strip_insignificant_zeros: true
-      = " "
-    ·
+
+  .detailed-status__meta.rebfavs
     - if status.direct_visibility?
       %span.detailed-status__link<
         = fa_icon('envelope')
@@ -71,13 +71,18 @@
       = link_to remote_interaction_path(status, type: :reblog), class: 'modal-button detailed-status__link' do
         = fa_icon('retweet')
         %span.detailed-status__reblogs>= number_to_human status.reblogs_count, strip_insignificant_zeros: true
-        = " "
-    ·
+        %span.mini-avatars
+          - @reblogged_accounts.each do |account|
+            = mini_account account
+
+  .detailed-status__meta.rebfavs
     = link_to remote_interaction_path(status, type: :favourite), class: 'modal-button detailed-status__link' do
       = fa_icon('star')
       %span.detailed-status__favorites>= number_to_human status.favourites_count, strip_insignificant_zeros: true
-      = " "
+      %span.mini-avatars
+        - @favourited_accounts.each do |account|
+          = mini_account account
 
+  .detailed-status__meta
     - if user_signed_in?
-      ·
       = link_to t('statuses.open_in_web'), web_url("statuses/#{status.id}"), class: 'detailed-status__application', target: '_blank'


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/30565780/67138793-c1593f80-f283-11e9-95d9-bf3fc990600b.png)

![2](https://user-images.githubusercontent.com/30565780/67138792-c1593f80-f283-11e9-9a5a-fcdd8a4c771a.png)

note: `show more` link does not appear in static pages, because `REBFAV_ACCOUNTS_LIMIT` is large enough (it limits 400).
