### PR TITLE
Fix static pages: rebfavs link, display counts on tilmeline

### DIFF
--- a/app/helpers/mini_account_helper.rb
+++ b/app/helpers/mini_account_helper.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 module MiniAccountHelper
-  def mini_account(account, size: 24)
+  def mini_account(account, size: 24, path: nil)
     content_tag(:div, class: 'mini-avatar') do
       content_tag(:div, class: 'account__avatar-wrapper') do
-        content_tag(:div, '', class: 'account__avatar account__avatar-inline', style: "width: #{size}px; height: #{size}px; background-size: #{size}px #{size}px; background-image: url(#{full_asset_url(current_account&.user&.setting_auto_play_gif ? account.avatar_original_url : account.avatar_static_url)})")
+        link_to(path || ActivityPub::TagManager.instance.url_for(account), class: 'account__display-name') do
+          content_tag(:div, '', class: 'account__avatar account__avatar-inline', style: "width: #{size}px; height: #{size}px; background-size: #{size}px #{size}px; background-image: url(#{full_asset_url(current_account&.user&.setting_auto_play_gif ? account.avatar_original_url : account.avatar_static_url)})")
+        end
       end
     end
   end

--- a/app/javascript/mastodon/components/account_mini.js
+++ b/app/javascript/mastodon/components/account_mini.js
@@ -2,25 +2,28 @@ import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import Avatar from './avatar';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+import Permalink from '../components/permalink';
 
 export default class AccountMini extends ImmutablePureComponent {
 
-  static propTypes = {
-    account: ImmutablePropTypes.map.isRequired,
-  };
+static propTypes = {
+  account: ImmutablePropTypes.map.isRequired,
+};
 
-  render () {
-    const { account } = this.props;
-    if (!account) {
-      return <div />;
-    }
-    return (
-      <div className='mini-avatar'>
-        <div className='account__avatar-wrapper' title={account.get('acct')}>
-          <Avatar account={account} size={24} inline />
-        </div>
-      </div>
-    );
+render () {
+  const { account } = this.props;
+  if (!account) {
+    return <div />;
   }
+  return (
+    <div className='mini-avatar'>
+      <div className='account__avatar-wrapper' title={account.get('acct')}>
+        <Permalink key={account.get('id')} className='account__display-name' title={account.get('acct')} href={account.get('url')} to={`/accounts/${account.get('id')}`}>
+          <Avatar account={account} size={24} inline />
+        </Permalink>
+      </div>
+    </div>
+  );
+}
 
 }

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -115,6 +115,8 @@ class DetailedStatus extends ImmutablePureComponent {
     let favouriteLink = '';
     let rebloggedAccounts = '';
     let favouritedAccounts = '';
+    let rebloggedAccountsMore = '';
+    let favouritedAccountsMore = '';
 
     if (this.props.measureHeight) {
       outerStyle.height = `${this.state.height}px`;
@@ -180,8 +182,15 @@ class DetailedStatus extends ImmutablePureComponent {
 
     if (rebloggedAccountIds && rebloggedAccountIds.size > 0) {
       rebloggedAccounts = rebloggedAccountIds.map(id => (
-        <AccountMiniContainer reblog key={id} id={id} />
+        <div key={id} className='mini-avatars'><AccountMiniContainer reblog id={id} /></div>
       ));
+      if (rebloggedAccountIds.size >= 40) {
+        rebloggedAccountsMore = (
+          <Link to={`/statuses/${status.get('id')}/reblogs`} className='detailed-status__link'>
+            <div>{intl.formatMessage(messages.more)}</div>
+          </Link>
+        );
+      }
     }
 
     if (status.get('visibility') === 'private') {
@@ -193,10 +202,6 @@ class DetailedStatus extends ImmutablePureComponent {
           <span className='detailed-status__reblogs'>
             <FormattedNumber value={status.get('reblogs_count')} />
           </span>
-          <span className='mini-avatars'>{rebloggedAccounts}</span>
-          <div>
-            {rebloggedAccounts && rebloggedAccounts.size >= 40 && intl.formatMessage(messages.more)}
-          </div>
         </Link>
       );
     } else {
@@ -206,18 +211,21 @@ class DetailedStatus extends ImmutablePureComponent {
           <span className='detailed-status__reblogs'>
             <FormattedNumber value={status.get('reblogs_count')} />
           </span>
-          <span className='mini-avatars'>{rebloggedAccounts}</span>
-          <div>
-            {rebloggedAccounts && rebloggedAccounts.size >= 40 && intl.formatMessage(messages.more)}
-          </div>
         </a>
       );
     }
 
     if (favouritedAccountIds && favouritedAccountIds.size > 0) {
       favouritedAccounts = favouritedAccountIds.map(id => (
-        <AccountMiniContainer reblog={false} key={id} id={id} />
+        <div key={id} className='mini-avatars'><AccountMiniContainer reblog={false} id={id} /></div>
       ));
+      if (favouritedAccountIds.size >= 40) {
+        favouritedAccountsMore = (
+          <Link to={`/statuses/${status.get('id')}/favourites`} className='detailed-status__link'>
+            <div>{intl.formatMessage(messages.more)}</div>
+          </Link>
+        );
+      }
     }
 
     if (this.context.router) {
@@ -227,10 +235,6 @@ class DetailedStatus extends ImmutablePureComponent {
           <span className='detailed-status__favorites'>
             <FormattedNumber value={status.get('favourites_count')} />
           </span>
-          <span className='mini-avatars'>{favouritedAccounts}</span>
-          <div>
-            {favouritedAccounts && favouritedAccounts.size >= 40 && intl.formatMessage(messages.more)}
-          </div>
         </Link>
       );
     } else {
@@ -240,10 +244,6 @@ class DetailedStatus extends ImmutablePureComponent {
           <span className='detailed-status__favorites'>
             <FormattedNumber value={status.get('favourites_count')} />
           </span>
-          <span className='mini-avatars'>{favouritedAccounts}</span>
-          <div>
-            {favouritedAccounts && favouritedAccounts.size >= 40 && intl.formatMessage(messages.more)}
-          </div>
         </a>
       );
     }
@@ -267,9 +267,13 @@ class DetailedStatus extends ImmutablePureComponent {
           </div>
           <div className='detailed-status__meta rebfavs'>
             {reblogLink}
+            {rebloggedAccounts}
+            {rebloggedAccountsMore}
           </div>
           <div className='detailed-status__meta rebfavs'>
             {favouriteLink}
+            {favouritedAccounts}
+            {favouritedAccountsMore}
           </div>
         </div>
       </div>

--- a/app/javascript/styles/mastodon/mini_avatars.scss
+++ b/app/javascript/styles/mastodon/mini_avatars.scss
@@ -1,33 +1,31 @@
 .rebfavs {
   background: lighten($ui-base-color, 4%);
 
-  a {
-    display: flex;
-    align-items: center;
-    white-space: nowrap;
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
 
-    i {
+  i {
+    display: inline-flex;
+    min-width: 16px;
+  }
+
+  .detailed-status {
+    &__reblogs,&__favorites {
       display: inline-flex;
+      margin: 0 4px;
       min-width: 16px;
+      font-size: 14px;
     }
+  }
 
-    .detailed-status {
-      &__reblogs,&__favorites {
-        display: inline-flex;
-        margin: 0 4px;
-        min-width: 16px;
-        font-size: 14px;
-      }
-    }
+  .mini-avatars {
+    display: inline-flex;
+    flex-wrap: wrap;
 
-    .mini-avatars {
-      display: inline-flex;
-      flex-wrap: wrap;
-
-      .mini-avatar {
-        .account__avatar-wrapper {
-          margin: 2px 0;
-        }
+    .mini-avatar {
+      .account__avatar-wrapper {
+        margin: 2px 0;
       }
     }
   }

--- a/app/views/statuses/_detailed_status.html.haml
+++ b/app/views/statuses/_detailed_status.html.haml
@@ -71,17 +71,17 @@
       = link_to remote_interaction_path(status, type: :reblog), class: 'modal-button detailed-status__link' do
         = fa_icon('retweet')
         %span.detailed-status__reblogs>= number_to_human status.reblogs_count, strip_insignificant_zeros: true
-        %span.mini-avatars
-          - @reblogged_accounts.each do |account|
-            = mini_account account
+      %div.mini-avatars
+        - @reblogged_accounts.each do |account|
+          = mini_account account
 
   .detailed-status__meta.rebfavs
     = link_to remote_interaction_path(status, type: :favourite), class: 'modal-button detailed-status__link' do
       = fa_icon('star')
       %span.detailed-status__favorites>= number_to_human status.favourites_count, strip_insignificant_zeros: true
-      %span.mini-avatars
-        - @favourited_accounts.each do |account|
-          = mini_account account
+    %div.mini-avatars
+      - @favourited_accounts.each do |account|
+        = mini_account account
 
   .detailed-status__meta
     - if user_signed_in?

--- a/app/views/statuses/_simple_status.html.haml
+++ b/app/views/statuses/_simple_status.html.haml
@@ -53,12 +53,16 @@
         - else
           = fa_icon 'reply-all fw'
       .status__action-bar__counter__label= obscured_counter status.replies_count
-    = link_to remote_interaction_path(status, type: :reblog), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do
-      - if status.distributable?
-        = fa_icon 'retweet fw'
-      - elsif status.private_visibility? || status.limited_visibility?
-        = fa_icon 'lock fw'
-      - else
-        = fa_icon 'envelope fw'
-    = link_to remote_interaction_path(status, type: :favourite), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do
-      = fa_icon 'star fw'
+    .status__action-bar__counter
+      = link_to remote_interaction_path(status, type: :reblog), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do
+        - if status.distributable?
+          = fa_icon 'retweet fw'
+        - elsif status.private_visibility? || status.limited_visibility?
+          = fa_icon 'lock fw'
+        - else
+          = fa_icon 'envelope fw'
+      .status__action-bar__counter__label>= number_to_human status.reblogs_count, strip_insignificant_zeros: true
+    .status__action-bar__counter
+      = link_to remote_interaction_path(status, type: :favourite), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do
+        = fa_icon 'star fw'
+      .status__action-bar__counter__label>= number_to_human status.favourites_count, strip_insignificant_zeros: true


### PR DESCRIPTION
- rebfav avatars links to their account page (both web ui/static pages)
- display rebfav counts on static pages timeline

![1](https://user-images.githubusercontent.com/30565780/67156989-a14b7e00-f360-11e9-884c-73ca2163b8e8.png)
