### PR TITLE
Experimental: swipeable threashold configuration

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -60,6 +60,8 @@ export const COMPOSE_POLL_OPTION_CHANGE   = 'COMPOSE_POLL_OPTION_CHANGE';
 export const COMPOSE_POLL_OPTION_REMOVE   = 'COMPOSE_POLL_OPTION_REMOVE';
 export const COMPOSE_POLL_SETTINGS_CHANGE = 'COMPOSE_POLL_SETTINGS_CHANGE';
 
+export const CHANGE_SWIPEABLE_THRESHOLD = 'CHANGE_SWIPEABLE_THRESHOLD';
+
 const messages = defineMessages({
   uploadErrorLimit: { id: 'upload_error.limit', defaultMessage: 'File upload limit exceeded.' },
   uploadErrorPoll:  { id: 'upload_error.poll', defaultMessage: 'File upload not allowed with polls.' },
@@ -639,3 +641,10 @@ export function changePollSettings(expiresIn, isMultiple) {
     isMultiple,
   };
 };
+
+export function changeSwipeableThreshold(swipeableThreshold) {
+  return {
+    type: CHANGE_SWIPEABLE_THRESHOLD,
+    swipeableThreshold,
+  };
+}

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -63,6 +63,8 @@ class ComposeForm extends ImmutablePureComponent {
     showSearch: PropTypes.bool,
     anyMedia: PropTypes.bool,
     singleColumn: PropTypes.bool,
+    onChangeSwipeableThreshold: PropTypes.func.isRequired,
+    swipeableThreshold: PropTypes.string,
   };
 
   static defaultProps = {
@@ -130,6 +132,11 @@ class ComposeForm extends ImmutablePureComponent {
         this.composeForm.scrollIntoView();
       }
     }
+  }
+
+  handleChangeSwipeableThreshold = () => {
+    const swipeableThreshold = window.prompt('Input threshold (NOTE: This value is NOT saved, restored to the default value 5 at the next load). See "About threshold" for details.', this.props.swipeableThreshold || '5');
+    if (swipeableThreshold && parseInt(swipeableThreshold)) this.props.onChangeSwipeableThreshold(parseInt(swipeableThreshold));
   }
 
   componentDidUpdate (prevProps) {
@@ -268,6 +275,9 @@ class ComposeForm extends ImmutablePureComponent {
 
           <div className='compose-form__publish-button-wrapper'><Button text={publishText} onClick={this.handleSubmit} disabled={disabledButton} block /></div>
         </div>
+
+        <Button onClick={this.handleChangeSwipeableThreshold} style={{ margin: '40px 0' }} block secondary>change swipeable threshold</Button>
+        <span className='getting-started__footer'><a href='https://react-swipeable-views.com/api/api/#swipeableviews' target='_blank'>About threshold</a></span>
       </div>
     );
   }

--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -9,6 +9,7 @@ import {
   changeComposeSpoilerText,
   insertEmojiCompose,
   uploadCompose,
+  changeSwipeableThreshold,
 } from '../../../actions/compose';
 
 const mapStateToProps = state => ({
@@ -25,6 +26,7 @@ const mapStateToProps = state => ({
   isUploading: state.getIn(['compose', 'is_uploading']),
   showSearch: state.getIn(['search', 'submitted']) && !state.getIn(['search', 'hidden']),
   anyMedia: state.getIn(['compose', 'media_attachments']).size > 0,
+  swipeableThreshold: state.get('swipeableThreshold'),
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -61,6 +63,9 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(insertEmojiCompose(position, data, needsSpace));
   },
 
+  onChangeSwipeableThreshold(swipeableThreshold) {
+    dispatch(changeSwipeableThreshold(swipeableThreshold));
+  },
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ComposeForm);

--- a/app/javascript/mastodon/features/ui/components/columns_area.js
+++ b/app/javascript/mastodon/features/ui/components/columns_area.js
@@ -63,6 +63,7 @@ class ColumnsArea extends ImmutablePureComponent {
     isModalOpen: PropTypes.bool.isRequired,
     singleColumn: PropTypes.bool,
     children: PropTypes.node,
+    swipeableThreshold: PropTypes.number,
   };
 
   state = {
@@ -176,13 +177,15 @@ class ColumnsArea extends ImmutablePureComponent {
     const { columns, children, singleColumn, isModalOpen, intl } = this.props;
     const { shouldAnimate } = this.state;
 
+    const { swipeableThreshold } = this.props.swipeableThreshold ? this.props.swipeableThreshold : 5;
+
     const columnIndex = getIndex(this.context.router.history.location.pathname);
 
     if (singleColumn) {
       const floatingActionButton = shouldHideFAB(this.context.router.history.location.pathname) ? null : <Link key='floating-action-button' to='/statuses/new' className='floating-action-button' aria-label={intl.formatMessage(messages.publish)}><Icon id='pencil' /></Link>;
 
       const content = columnIndex !== -1 ? (
-        <ReactSwipeableViews key='content' index={columnIndex} onChangeIndex={this.handleSwipe} onTransitionEnd={this.handleAnimationEnd} animateTransitions={shouldAnimate} springConfig={{ duration: '400ms', delay: '0s', easeFunction: 'ease' }} style={{ height: '100%' }} disabled>
+        <ReactSwipeableViews key='content' index={columnIndex} onChangeIndex={this.handleSwipe} onTransitionEnd={this.handleAnimationEnd} animateTransitions={shouldAnimate} springConfig={{ duration: '400ms', delay: '0s', easeFunction: 'ease' }} style={{ height: '100%' }} threshold={swipeableThreshold}>
           {links.map(this.renderView)}
         </ReactSwipeableViews>
       ) : (

--- a/app/javascript/mastodon/features/ui/containers/columns_area_container.js
+++ b/app/javascript/mastodon/features/ui/containers/columns_area_container.js
@@ -4,6 +4,7 @@ import ColumnsArea from '../components/columns_area';
 const mapStateToProps = state => ({
   columns: state.getIn(['settings', 'columns']),
   isModalOpen: !!state.get('modal').modalType,
+  swipeableThreshold: state.getIn(['compose', 'swipeable_threshold']),
 });
 
 export default connect(mapStateToProps, null, null, { forwardRef: true })(ColumnsArea);

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -35,6 +35,7 @@ import {
   COMPOSE_POLL_OPTION_CHANGE,
   COMPOSE_POLL_OPTION_REMOVE,
   COMPOSE_POLL_SETTINGS_CHANGE,
+  CHANGE_SWIPEABLE_THRESHOLD,
 } from '../actions/compose';
 import { TIMELINE_DELETE } from '../actions/timelines';
 import { STORE_HYDRATE } from '../actions/store';
@@ -413,6 +414,8 @@ export default function compose(state = initialState, action) {
     return state.updateIn(['poll', 'options'], options => options.delete(action.index));
   case COMPOSE_POLL_SETTINGS_CHANGE:
     return state.update('poll', poll => poll.set('expires_in', action.expiresIn).set('multiple', action.isMultiple));
+  case CHANGE_SWIPEABLE_THRESHOLD:
+    return state.set('swipeable_threshold', action.swipeableThreshold);
   default:
     return state;
   }


### PR DESCRIPTION
swipeable コンポーネントの threshold というプロパティを変更できるボタンを投稿画面に追加します。ふるどんユーザに試してもらうための一時的な機能です。そのため最低限の実装になっています。

<img width="585" alt="2" src="https://user-images.githubusercontent.com/30565780/67157032-377fa400-f361-11e9-94c6-b3fd7d9f80e2.png">
